### PR TITLE
Use with-eval-after-load for sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ In your `init.el`:
 
 ```elisp
 (require 'flycheck-swift3) ; Not necessary if using ELPA package
-(eval-after-load 'flycheck
-  '(add-hook 'flycheck-mode-hook #'flycheck-swift3-setup))
+(with-eval-after-load 'flycheck
+  (add-hook 'flycheck-mode-hook #'flycheck-swift3-setup))
 ```
 
 ## License

--- a/flycheck-swift3.el
+++ b/flycheck-swift3.el
@@ -48,8 +48,8 @@
 ;;
 ;; Usage:
 ;;
-;; (eval-after-load 'flycheck
-;;   '(add-hook 'flycheck-mode-hook #'flycheck-swift3-setup))
+;; (with-eval-after-load 'flycheck
+;;   (add-hook 'flycheck-mode-hook #'flycheck-swift3-setup))
 
 ;;; Code:
 


### PR DESCRIPTION
It is introduced since Emacs 24.4, and it is preferable to eval-after-load.
It does not require quote, progn, lambda.